### PR TITLE
Updated `py` dependency from 1.9.0 to 1.10.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,31 +4,75 @@
 #
 #    pip-compile requirements-dev.in
 #
-appdirs==1.4.4            # via black
-attrs==19.3.0             # via flake8-bugbear, flake8-implicit-str-concat, pytest
-black==20.8b1             # via -r requirements-dev.in
-click==7.1.2              # via black
-coverage==5.2.1           # via pytest-cov
-flake8-bugbear==20.1.4    # via -r requirements-dev.in
-flake8-comprehensions==3.2.3  # via -r requirements-dev.in
-flake8-implicit-str-concat==0.1.0  # via -r requirements-dev.in
-flake8==3.8.3             # via -r requirements-dev.in, flake8-bugbear, flake8-comprehensions
-iniconfig==1.0.1          # via pytest
-mccabe==0.6.1             # via flake8
-more-itertools==8.5.0     # via pytest
-mypy-extensions==0.4.3    # via black, mypy
-mypy==0.782               # via -r requirements-dev.in
-packaging==20.4           # via pytest
-pathspec==0.8.0           # via black
-pluggy==0.13.1            # via pytest
-py==1.9.0                 # via pytest
-pycodestyle==2.6.0        # via flake8
-pyflakes==2.2.0           # via flake8
-pyparsing==2.4.7          # via packaging
-pytest-cov==2.10.1        # via -r requirements-dev.in
-pytest==6.0.1             # via -r requirements-dev.in, pytest-cov
-regex==2020.7.14          # via black
-six==1.15.0               # via packaging
-toml==0.10.1              # via black, pytest
-typed-ast==1.4.1          # via black, mypy
-typing-extensions==3.7.4.3  # via black, mypy
+appdirs==1.4.4
+    # via black
+attrs==19.3.0
+    # via
+    #   flake8-bugbear
+    #   flake8-implicit-str-concat
+    #   pytest
+black==20.8b1
+    # via -r requirements-dev.in
+click==7.1.2
+    # via black
+coverage==5.2.1
+    # via pytest-cov
+flake8-bugbear==20.1.4
+    # via -r requirements-dev.in
+flake8-comprehensions==3.2.3
+    # via -r requirements-dev.in
+flake8-implicit-str-concat==0.1.0
+    # via -r requirements-dev.in
+flake8==3.8.3
+    # via
+    #   -r requirements-dev.in
+    #   flake8-bugbear
+    #   flake8-comprehensions
+iniconfig==1.0.1
+    # via pytest
+mccabe==0.6.1
+    # via flake8
+more-itertools==8.5.0
+    # via pytest
+mypy-extensions==0.4.3
+    # via
+    #   black
+    #   mypy
+mypy==0.782
+    # via -r requirements-dev.in
+packaging==20.4
+    # via pytest
+pathspec==0.8.0
+    # via black
+pluggy==0.13.1
+    # via pytest
+py==1.10.0
+    # via pytest
+pycodestyle==2.6.0
+    # via flake8
+pyflakes==2.2.0
+    # via flake8
+pyparsing==2.4.7
+    # via packaging
+pytest-cov==2.10.1
+    # via -r requirements-dev.in
+pytest==6.0.1
+    # via
+    #   -r requirements-dev.in
+    #   pytest-cov
+regex==2020.7.14
+    # via black
+six==1.15.0
+    # via packaging
+toml==0.10.1
+    # via
+    #   black
+    #   pytest
+typed-ast==1.4.1
+    # via
+    #   black
+    #   mypy
+typing-extensions==3.7.4.3
+    # via
+    #   black
+    #   mypy


### PR DESCRIPTION
### **User description**
Bumps [py](https://github.com/pytest-dev/py) from 1.9.0 to 1.10.0.
- [Release notes](https://github.com/pytest-dev/py/releases)
- [Changelog](https://github.com/pytest-dev/py/blob/master/CHANGELOG.rst)
- [Commits](https://github.com/pytest-dev/py/compare/1.9.0...1.10.0)

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed


___

### **Description**
- Updated the `py` dependency from version 1.9.0 to 1.10.0 in the `requirements-dev.txt` file.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependency</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>requirements-dev.txt</strong><dd><code>Updated `py` dependency version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

requirements-dev.txt
['Updated `py` dependency from 1.9.0 to 1.10.0']


</details>


  </td>
  <td><a href="https://github.com/2lambda123/camelot-dev-excalibur/pull/5/files#diff-2b4945591edfeaa4cf4d3f155e66d4b43d1bda7a55d881d5cf3107f1b05abbbc">+72/-28</a>&nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>